### PR TITLE
Added support for listening for UDP on IPv6 networks

### DIFF
--- a/protected.go
+++ b/protected.go
@@ -333,7 +333,8 @@ func (p *Protector) listenUDP(network string, laddr *net.UDPAddr) (*net.UDPConn,
 		return nil, errors.New("Unsupported network: %v", network)
 	}
 
-	socketFd, err := syscall.Socket(syscall.AF_INET, syscall.SOCK_DGRAM, syscall.IPPROTO_UDP)
+	sockAddr, family, _ := socketAddr(&net.IPAddr{IP: laddr.IP}, laddr.Port)
+	socketFd, err := syscall.Socket(family, syscall.SOCK_DGRAM, syscall.IPPROTO_UDP)
 	if err != nil {
 		return nil, errors.New("Could not create socket: %v", err)
 	}
@@ -347,9 +348,7 @@ func (p *Protector) listenUDP(network string, laddr *net.UDPAddr) (*net.UDPConn,
 			socketFd, err)
 	}
 
-	sa := &syscall.SockaddrInet4{Port: laddr.Port}
-	copy(sa.Addr[:], laddr.IP.To4())
-	err = syscall.Bind(socketFd, sa)
+	err = syscall.Bind(socketFd, sockAddr)
 	if err != nil {
 		return nil, errors.New("Unable to bind socket with fd %v: %v",
 			socketFd, err)

--- a/protected_test.go
+++ b/protected_test.go
@@ -126,8 +126,16 @@ func TestDialUDP(t *testing.T) {
 	assert.NotEqual(t, 0, p.lastProtected, "Should have gotten file descriptor from protecting")
 }
 
-func TestListenUDP(t *testing.T) {
-	l, err := net.ListenPacket("udp4", ":53243")
+func TestListenUDPv4(t *testing.T) {
+	doTestListenUDP(t, net.IPv4zero, "udp4", "localhost:53243")
+}
+
+func TestListenUDPv6(t *testing.T) {
+	doTestListenUDP(t, net.IPv6zero, "udp6", "localhost:53243")
+}
+
+func doTestListenUDP(t *testing.T, zeroAddr net.IP, network, addr string) {
+	l, err := net.ListenPacket(network, addr)
 	if !assert.NoError(t, err) {
 		return
 	}
@@ -144,7 +152,7 @@ func TestListenUDP(t *testing.T) {
 	p := &testprotector{}
 	pt := New(p.Protect, func() string { return "8.8.8.8" })
 
-	conn, err := pt.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4zero, Port: 0})
+	conn, err := pt.ListenUDP(network, &net.UDPAddr{IP: zeroAddr, Port: 0})
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
This is to help with getting QUIC working on NAT64 networks. By itself, it does not appear to be enough - QUIC still times out trying to dial the proxy.

- [x] Do the tests pass? Consistently?
- [x] Did this change improve test coverage?
- [ ] Has it been reviewed/approved by relevant teammates?
- [ ] Can it be QA’d in staging or something like staging?
- [ ] Is the code in question being linted? If not, consider adding a linter step to CI. If yes, make sure the linter is happy.
- [ ] Do we know how we’re going to deploy this?
- [ ] Are we clear on what the support and maintenance impact is?
- [ ] Did you create new documentation? Is it accessible and in the right place?
- [ ] Has existing documentation been updated?
- [ ] Have you logged tickets for related technical debt with the label “techdebt”?